### PR TITLE
Update Renovate bot to not update to major releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,11 @@
   "labels": [
     "changelog:dependencies"
   ],
-  "suppressNotifications": ["prEditedNotification"]
+  "suppressNotifications": ["prEditedNotification"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    }
+  ]
 }


### PR DESCRIPTION
Per the tutorial this will limit major updates to on-demand creation via the Dependency Dashboard https://github.com/renovatebot/tutorial